### PR TITLE
Update Makefile to place objects in build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,27 @@ CXX = g++
 CXXFLAGS = -std=c++11 `pkg-config --cflags opencv4`
 LDFLAGS = `pkg-config --libs opencv4`
 
-SRC_DIR = src/camera
-SRC = $(SRC_DIR)/camera.cpp
-TARGET = $(SRC_DIR)/camera
+SRC_DIR := src/camera
+BUILD_DIR := build
+SRC := $(SRC_DIR)/camera.cpp
+OBJ := $(BUILD_DIR)/camera.o
+TARGET := $(SRC_DIR)/camera
 
 all: $(TARGET)
 
-$(TARGET): $(SRC)
+$(BUILD_DIR):
+	mkdir -p $@
+
+$(OBJ): $(SRC) | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(TARGET): $(OBJ)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(OBJ)
 
 run: $(TARGET)
 	./$(TARGET)
 
-.PHONY: all clean
+.PHONY: all clean run


### PR DESCRIPTION
## Summary
- update Makefile to compile object files into `build/`
- add target for creating `build` directory
- clean up object files in `make clean`

## Testing
- `make` *(fails: Package 'opencv4' not found)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_6860ee1f7a10832a8be39ef9961a367d